### PR TITLE
fix forward probability calculations - see algorithm 1 in the NADE paper

### DIFF
--- a/model.py
+++ b/model.py
@@ -15,28 +15,28 @@ class NADE(nn.Module):
         })
         nn.init.xavier_normal_(self.params["V"])
         nn.init.xavier_normal_(self.params["W"])
-        
+
     def forward(self, x):
         # a0: (B, H)
         a_d = self.params["c"].expand(x.size(0), -1)
         # Compute p(x)
         x_hat = self._cal_prob(a_d, x)
-        
+
         return x_hat
-    
+
     def _cal_prob(self, a_d, x, sample=False):
         """
         assert 'x = None' when sampling
         Parameters:
          - a_d : (B, H)
          - x : (B, D)
-         
+
         Return:
          - x_hat: (B, D), estimated probability dist. of batch data
         """
         if sample:
             assert (x is None), "No input for sampling as first time"
-        
+
         x_hat = []  # (B, 1) x D
         xs = []
         for d in range(self.D):
@@ -45,28 +45,28 @@ class NADE(nn.Module):
             # p_hat: (B, H) x (H, 1) + (B, 1) = (B, 1)
             p_hat = torch.sigmoid(h_d.mm(self.params["V"][d:d+1, :].t() + self.params["b"][d:d+1]))
             x_hat.append(p_hat)
-            
+
             if sample:
                 # random sample x: (B, 1) > a_{d+1}: (B, 1) x (1, H)
                 x = torch.distributions.Bernoulli(probs=p_hat).sample()
                 xs.append(x)
-                a_d = x.mm(self.params["W"][:, d:d+1].t()) + self.params["c"]
-                
+                a_d = a_d + x.mm(self.params["W"][:, d:d+1].t())
+
             else:
                 # a_{d+1}: (B, 1) x (1, H)
-                a_d = x[:, d:d+1].mm(self.params["W"][:, d:d+1].t()) + self.params["c"]
-        
+                a_d = a_d + x[:, d:d+1].mm(self.params["W"][:, d:d+1].t())
+
         # x_hat: (B, D), estimated probability dist. of batch data
         x_hat = torch.cat(x_hat, 1)
         if sample:
             xs = torch.cat(xs, 1)
             return x_hat, xs
         return x_hat
-    
+
     def _cal_nll(self, x_hat, x):
         nll_loss = -1 * ( x*torch.log(x_hat + 1e-10) + (1-x)*torch.log(1-x_hat + 1e-10))
         return nll_loss
-    
+
     def sample(self, n=1, only_prob=True):
         a_d = self.params["c"].expand(n, -1)  # (n, H)
         # Compute p(x)


### PR DESCRIPTION
Hi Simon!  This is random but I was using your NADE implementation as part of a graduate seminar class in generative deep learning models and I noticed that the forward probability calculation was incorrect.  I made the changes - you can check them against Algorithm 1 in the original NADE paper.  I ran the fixed version and was able to achieve lower loss values and better sampling on the MNIST dataset.